### PR TITLE
Multiplication error in Calculator.mult() fixed

### DIFF
--- a/Calculator.java
+++ b/Calculator.java
@@ -46,7 +46,7 @@ public class Calculator {
 	 * @return x * y
 	 */
 	public double mult(double x, double y) {
-		return x;
+		return x * y;
 	}
 
 	/**


### PR DESCRIPTION
The Calculator.mult() method originally returned only x. It now returns x * y, allowing it to properly multiply the two values.

Closes #3 