### PR TITLE
fixed mult method to correctly multiply the parameter values

### DIFF
--- a/Calculator.java
+++ b/Calculator.java
@@ -46,7 +46,7 @@ public class Calculator {
 	 * @return x * y
 	 */
 	public double mult(double x, double y) {
-		return x;
+		return x * y;
 	}
 
 	/**


### PR DESCRIPTION
changed the return statement in the method "mult" from "return x;" to "return x * y;" to fix the method so that it correctly multiplies the given parameters and returns the result.