### PR TITLE
Adding changes to bug in line 103 (fixing rectangle perimeter method)

### DIFF
--- a/Calculator.java
+++ b/Calculator.java
@@ -100,7 +100,7 @@ public class Calculator {
 	 * @return the perimeter of a rectangle with sides x and y.
 	 */
 	public double rectPer(double x, double y) {
-		return 2 * x * y;
+		return 2 * (x + y);
 	}
 
 	/**


### PR DESCRIPTION
In line 103 in the rectPer method, fixed arithmetic error for calculating perimeter of a rectangle from 2 * x * y to 2 * (x+y)