### PR TITLE
Fixed bug in line 125 in cirPer method (fixed circle perimeter formula)

### DIFF
--- a/Calculator.java
+++ b/Calculator.java
@@ -122,7 +122,7 @@ public class Calculator {
 	 * @return the perimeter of a circle with radius r.
 	 */
 	public double cirPer(double r) {
-		return Math.PI * r * r;
+		return Math.PI * 2 * r;
 	}
 
 	/**


### PR DESCRIPTION
In line 125, which contains the return statement for the cirPer method which calculates the perimeter of a circle with r radius, I fixed the formula which was previously PI * r * r to PI * 2 * r